### PR TITLE
python-scikitlearn: 1.1.1 new release

### DIFF
--- a/package/python-scikitlearn/python-scikitlearn.hash
+++ b/package/python-scikitlearn/python-scikitlearn.hash
@@ -1,4 +1,4 @@
 # Locally calculated
-sha256  34471662f0e5ba8d2c799391338c6f976680cc66b715e00db0c7589f4f371bc4  python-scikitlearn-1.0.2.tar.gz
+sha256  568e621b9e1479b9ab952a9241db5af2ba3ab4f69d44b8aba3dd7648825e8e5a  python-scikitlearn-1.1.1.tar.gz
 # License files, locally calculated
 sha256  bc2e5553b31344779335ddadac8de6f9d12da6f4ce46e22a8e2820951a1d5458  COPYING

--- a/package/python-scikitlearn/python-scikitlearn.mk
+++ b/package/python-scikitlearn/python-scikitlearn.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PYTHON_SCIKITLEARN_VERSION = 1.0.2
+PYTHON_SCIKITLEARN_VERSION = 1.1.1
 PYTHON_SCIKITLEARN_SITE = $(call github,scikit-learn,scikit-learn,$(PYTHON_SCIKITLEARN_VERSION))
 PYTHON_SCIKITLEARN_LICENSE = BSD-3-Clause
 PYTHON_SCIKITLEARN_LICENSE_FILES = COPYING


### PR DESCRIPTION
scikitlearn 1.1.1: new release

* [changelog](https://scikit-learn.org/dev/whats_new/v1.1.html#version-1-1-1)