### PR TITLE
python-sklearn 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ make raspberrypi3_64_scipy_defconfig
 make raspberrypi4_64_scipy_defconfig
 ```
 
-### Sklearn: machine learning toolkit
+### Sklearn: python machine learning toolkit
 
 Package `python-scikitlearn` requires `scipy` and 
-an extra buildroot patch to be applied prior anything, similarly to the `gr-osmosdr` tweak:
+an extra buildroot patch to be applied prior getting started, similarly to `gr-osmosdr`:
 
 ```bash
 source sourceme.ggm

--- a/package/python-joblib/python-joblib.hash
+++ b/package/python-joblib/python-joblib.hash
@@ -1,3 +1,3 @@
 # Locally calculated
-sha256  4cda464ca712a4814849c9477d7551b696ce215dc05d79fc516460814ef48f4f  python-joblib-1.1.0.tar.gz
+sha256  34c7b4c5fc5b6ba65982dca55daceaa371a9003d8da7fe0f952e076e07e53910  python-joblib-1.1.1.tar.gz
 sha256  42612911c1872c5e4b43f6ae0e8ee59467cd350332241cf72ce90640264fae6a  LICENSE.txt

--- a/package/python-joblib/python-joblib.mk
+++ b/package/python-joblib/python-joblib.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PYTHON_JOBLIB_VERSION = 1.1.0
+PYTHON_JOBLIB_VERSION = 1.1.1
 PYTHON_JOBLIB_SITE = $(call github,joblib,joblib,$(PYTHON_JOBLIB_VERSION))
 PYTHON_JOBLIB_LICENSE = BSD-3-Clause
 PYTHON_JOBLIB_LICENSE_FILES = LICENSE.txt

--- a/package/python-scikitlearn/python-scikitlearn.hash
+++ b/package/python-scikitlearn/python-scikitlearn.hash
@@ -1,4 +1,4 @@
 # Locally calculated
-sha256  568e621b9e1479b9ab952a9241db5af2ba3ab4f69d44b8aba3dd7648825e8e5a  python-scikitlearn-1.1.1.tar.gz
+sha256  b7c0a9fb8dfcefcfc7ef8fe02a064d194980251d57efaea972cb76005afb3c63  python-scikitlearn-1.1.3.tar.gz
 # License files, locally calculated
 sha256  bc2e5553b31344779335ddadac8de6f9d12da6f4ce46e22a8e2820951a1d5458  COPYING

--- a/package/python-scikitlearn/python-scikitlearn.mk
+++ b/package/python-scikitlearn/python-scikitlearn.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PYTHON_SCIKITLEARN_VERSION = 1.1.1
+PYTHON_SCIKITLEARN_VERSION = 1.1.3
 PYTHON_SCIKITLEARN_SITE = $(call github,scikit-learn,scikit-learn,$(PYTHON_SCIKITLEARN_VERSION))
 PYTHON_SCIKITLEARN_LICENSE = BSD-3-Clause
 PYTHON_SCIKITLEARN_LICENSE_FILES = COPYING

--- a/scikitlearn-support.patch
+++ b/scikitlearn-support.patch
@@ -1,29 +1,31 @@
-From 7ea6a82abd2ca2204726f6ba1c2b93f52ef24e2f Mon Sep 17 00:00:00 2001
+From 9aeef473bdfc5d6666e6c9df9622502789b730bf Mon Sep 17 00:00:00 2001
 From: "Guillaume W. Bres" <guillaume.bressaix@gmail.com>
-Date: Sun, 20 Feb 2022 15:41:55 +0100
-Subject: [PATCH] unlock scikitlearn dependencies
+Date: Mon, 31 Oct 2022 18:46:58 +0100
+Subject: [PATCH] package/python-scikitlearn: needs host-python-scipy,
+ host-lapack and host-python-pybind
 
 Signed-off-by: Guillaume W. Bres <guillaume.bressaix@gmail.com>
 ---
  package/lapack/lapack.mk               | 1 +
  package/openblas/openblas.mk           | 9 +++++++++
  package/python-pybind/python-pybind.mk | 1 +
- 3 files changed, 11 insertions(+)
+ package/python-scipy/python-scipy.mk   | 9 +++++++++
+ 4 files changed, 20 insertions(+)
 
 diff --git a/package/lapack/lapack.mk b/package/lapack/lapack.mk
-index 609075842d..cdae475097 100644
+index 3db2797..dc7ce1c 100644
 --- a/package/lapack/lapack.mk
 +++ b/package/lapack/lapack.mk
-@@ -23,3 +23,4 @@ LAPACK_CONF_OPTS += -DBUILD_COMPLEX=OFF -DBUILD_COMPLEX16=OFF
+@@ -28,3 +28,4 @@ LAPACK_CONF_OPTS += \
  endif
  
  $(eval $(cmake-package))
 +$(eval $(host-cmake-package))
 diff --git a/package/openblas/openblas.mk b/package/openblas/openblas.mk
-index 4d506fa618..824b6924c8 100644
+index 085d32a..a3480a1 100644
 --- a/package/openblas/openblas.mk
 +++ b/package/openblas/openblas.mk
-@@ -65,6 +65,10 @@ define OPENBLAS_BUILD_CMDS
+@@ -66,6 +66,10 @@ define OPENBLAS_BUILD_CMDS
  	$(TARGET_MAKE_ENV) $(MAKE) $(OPENBLAS_MAKE_OPTS) \
  		-C $(@D)
  endef
@@ -34,7 +36,7 @@ index 4d506fa618..824b6924c8 100644
  
  define OPENBLAS_INSTALL_STAGING_CMDS
  	$(TARGET_MAKE_ENV) $(MAKE) $(OPENBLAS_MAKE_OPTS) \
-@@ -75,5 +79,10 @@ define OPENBLAS_INSTALL_TARGET_CMDS
+@@ -76,5 +80,10 @@ define OPENBLAS_INSTALL_TARGET_CMDS
  	$(TARGET_MAKE_ENV) $(MAKE) $(OPENBLAS_MAKE_OPTS) \
  		-C $(@D) install PREFIX=$(TARGET_DIR)/usr
  endef
@@ -46,7 +48,7 @@ index 4d506fa618..824b6924c8 100644
  $(eval $(generic-package))
 +$(eval $(host-generic-package))
 diff --git a/package/python-pybind/python-pybind.mk b/package/python-pybind/python-pybind.mk
-index 7448d246b2..6389f3c6b2 100644
+index c5bee3d..24b3fc3 100644
 --- a/package/python-pybind/python-pybind.mk
 +++ b/package/python-pybind/python-pybind.mk
 @@ -26,3 +26,4 @@ endef
@@ -54,6 +56,30 @@ index 7448d246b2..6389f3c6b2 100644
  
  $(eval $(cmake-package))
 +$(eval $(host-cmake-package))
+diff --git a/package/python-scipy/python-scipy.mk b/package/python-scipy/python-scipy.mk
+index a8c23c6..5691ed4 100644
+--- a/package/python-scipy/python-scipy.mk
++++ b/package/python-scipy/python-scipy.mk
+@@ -31,6 +31,14 @@ PYTHON_SCIPY_DEPENDENCIES += \
+ 	lapack \
+ 	python-numpy \
+ 	python-pybind
++
++HOST_PYTHON_SCIPY_DEPENDENCIES += \
++	host-python-numpy \
++	host-python-pythran \
++	host-python-pybind \
++	host-lapack \
++	zlib
++
+ PYTHON_SCIPY_INSTALL_STAGING = YES
+ 
+ PYTHON_SCIPY_SETUP_TYPE = setuptools
+@@ -56,3 +64,4 @@ define PYTHON_SCIPY_CONFIGURE_CMDS
+ endef
+ 
+ $(eval $(python-package))
++$(eval $(host-python-package))
 -- 
-2.20.1
+1.8.3.1
 


### PR DESCRIPTION
* bump python-joblib to latest
* bump python-sklearn to latest
* fix host-python-scipy which is required to properly unlock python-sklearn, which is not supported natively by Buildroot to this day